### PR TITLE
Improve breakdown readability in dark mode

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -110,7 +110,7 @@
                                     </v-col>
                                 </v-row>
                                 <v-divider class="my-4"></v-divider>
-                                <v-list class="bg-transparent" lines="one">
+                                <v-list class="bg-transparent tax-breakdown" lines="one">
                                     <v-list-item prepend-icon="mdi-percent-outline">
                                         <v-list-item-title>Customs Duty</v-list-item-title>
                                         <template v-slot:append>
@@ -485,4 +485,11 @@ useHead({
     white-space: nowrap;
     overflow: hidden;
 }
+
+.tax-breakdown .v-list-item-title,
+.tax-breakdown .v-list-item .v-icon,
+.tax-breakdown .v-list-item span {
+    color: rgba(var(--v-theme-on-surface), 0.87) !important;
+}
+
 </style>

--- a/app/app.vue
+++ b/app/app.vue
@@ -72,7 +72,7 @@
                             </v-card-actions>
                         </v-card>
 
-                        <v-card v-if="results" class="mt-8 pa-6 results-card" variant="tonal" color="primary"
+                        <v-card v-if="results" class="mt-8 pa-0 results-card" variant="tonal" color="primary"
                             rounded="xl">
                             <v-card-title class="font-weight-bold text-center text-h5">Calculation
                                 Results</v-card-title>


### PR DESCRIPTION
## Summary
- Ensure tax breakdown list adapts to theme and uses high-contrast colors.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc8c8377a883239470003ef7647f37