### PR TITLE
feat: add PDF estimate generator

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -292,6 +292,7 @@ function onLogoChange(e) {
     const reader = new FileReader()
     reader.onload = evt => {
         estimateInfo.companyLogo = evt.target.result
+        if (results.value) generateEstimatePdf(false)
     }
     reader.readAsDataURL(file)
 }
@@ -443,8 +444,9 @@ async function generateEstimatePdf(download = false) {
     })
     const pdfBytes = await pdfDoc.save()
     const blob = new Blob([pdfBytes], { type: 'application/pdf' })
-    if (pdfPreviewUrl.value) URL.revokeObjectURL(pdfPreviewUrl.value)
+    const oldUrl = pdfPreviewUrl.value
     pdfPreviewUrl.value = URL.createObjectURL(blob)
+    if (oldUrl) URL.revokeObjectURL(oldUrl)
     if (download) {
         const link = document.createElement('a')
         link.href = pdfPreviewUrl.value

--- a/app/app.vue
+++ b/app/app.vue
@@ -72,10 +72,17 @@
                             </v-card-actions>
                         </v-card>
 
-                        <v-card v-if="results" class="mt-8 pa-0 results-card" variant="tonal" color="primary"
-                            rounded="xl">
-                            <v-card-title class="font-weight-bold text-center text-h5">Calculation
-                                Results</v-card-title>
+                        <div v-if="results" class="mt-8">
+                            <v-tabs v-model="activeTab" grow>
+                                <v-tab value="results">Results</v-tab>
+                                <v-tab value="estimate">Print Estimate</v-tab>
+                            </v-tabs>
+                            <v-window v-model="activeTab" class="mt-4">
+                                <v-window-item value="results">
+                                    <v-card class="pa-0 results-card" variant="tonal" color="primary"
+                                        rounded="xl">
+                                        <v-card-title class="font-weight-bold text-center text-h5">Calculation
+                                            Results</v-card-title>
                             <v-card-text>
                                 <v-row class="mb-4" justify="center">
                                     <v-col cols="12" md="4">
@@ -147,45 +154,42 @@
                                     </v-list-item>
                                 </v-list>
                         </v-card-text>
-                        </v-card>
+                          </v-card>
+                        </v-window-item>
+                        <v-window-item value="estimate">
+                          <v-card class="pa-4" rounded="xl">
+                            <v-form>
+                              <v-label class="font-weight-bold mb-1 d-block">Vehicle Details</v-label>
+                              <v-text-field v-model="estimateInfo.vehicleYear" label="Year" type="number"></v-text-field>
+                              <v-text-field v-model="estimateInfo.vehicleMake" label="Make"></v-text-field>
+                              <v-text-field v-model="estimateInfo.vehicleModel" label="Model"></v-text-field>
+                              <v-divider class="my-4"></v-divider>
+                              <v-label class="font-weight-bold mb-1 d-block">Customer Details</v-label>
+                              <v-text-field v-model="estimateInfo.customerFirstName" label="First Name"></v-text-field>
+                              <v-text-field v-model="estimateInfo.customerLastName" label="Last Name"></v-text-field>
+                              <v-text-field v-model="estimateInfo.customerEmail" label="Email" type="email"></v-text-field>
+                              <v-text-field v-model="estimateInfo.customerPhone" label="Phone" type="tel"></v-text-field>
+                              <v-divider class="my-4"></v-divider>
+                              <v-label class="font-weight-bold mb-1 d-block">Company Details</v-label>
+                              <v-text-field v-model="estimateInfo.companyName" label="Name"></v-text-field>
+                              <v-text-field v-model="estimateInfo.companyAddress" label="Address"></v-text-field>
+                              <v-text-field v-model="estimateInfo.companyEmail" label="Email" type="email"></v-text-field>
+                              <v-text-field v-model="estimateInfo.companyPhone" label="Phone"></v-text-field>
+                              <v-file-input label="Logo" accept="image/*" @change="onLogoChange"></v-file-input>
+                              <v-img v-if="estimateInfo.companyLogo" :src="estimateInfo.companyLogo" class="mt-2" max-height="100" contain></v-img>
+                            </v-form>
+                            <div class="text-center mt-4">
+                              <v-btn color="primary" @click="generateEstimatePdf">Download PDF</v-btn>
+                            </div>
+                            <div v-if="pdfPreviewUrl" class="mt-4">
+                              <iframe :src="pdfPreviewUrl" width="100%" height="600" style="border: none;"></iframe>
+                            </div>
+                          </v-card>
+                        </v-window-item>
+                      </v-window>
+                    </div>
 
-                        <v-btn v-if="results" class="mt-4" color="primary" @click="openEstimateDialog">
-                            Print Estimate
-                        </v-btn>
-
-                        <v-dialog v-model="estimateDialog" max-width="600">
-                            <v-card>
-                                <v-card-title class="text-h6 font-weight-bold">Print Estimate</v-card-title>
-                                <v-card-text>
-                                    <v-form>
-                                        <v-label class="font-weight-bold mb-1 d-block">Vehicle Details</v-label>
-                                        <v-text-field v-model="estimateInfo.vehicleYear" label="Year" type="number"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.vehicleMake" label="Make"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.vehicleModel" label="Model"></v-text-field>
-                                        <v-divider class="my-4"></v-divider>
-                                        <v-label class="font-weight-bold mb-1 d-block">Customer Details</v-label>
-                                        <v-text-field v-model="estimateInfo.customerFirstName" label="First Name"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.customerLastName" label="Last Name"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.customerEmail" label="Email" type="email"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.customerPhone" label="Phone" type="tel"></v-text-field>
-                                        <v-divider class="my-4"></v-divider>
-                                        <v-label class="font-weight-bold mb-1 d-block">Company Details</v-label>
-                                        <v-text-field v-model="estimateInfo.companyName" label="Name"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.companyAddress" label="Address"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.companyEmail" label="Email" type="email"></v-text-field>
-                                        <v-text-field v-model="estimateInfo.companyPhone" label="Phone"></v-text-field>
-                                        <v-file-input label="Logo" accept="image/*" @change="onLogoChange"></v-file-input>
-                                    </v-form>
-                                </v-card-text>
-                                <v-card-actions>
-                                    <v-spacer></v-spacer>
-                                    <v-btn text @click="estimateDialog = false">Cancel</v-btn>
-                                    <v-btn color="primary" @click="generateEstimatePdf">Download PDF</v-btn>
-                                </v-card-actions>
-                            </v-card>
-                        </v-dialog>
-
-                        <footer class="text-center text-caption text-medium-emphasis py-8">
+                          <footer class="text-center text-caption text-medium-emphasis py-8">
                             <p>
                                 This calculator is not affiliated with or endorsed by the
                                 <a href="https://www.gra.gov.gy/imports/motor-vehicle/" target="_blank" rel="noopener"
@@ -235,8 +239,8 @@ const processingFee = 0 // GYD processing fee
 const cifRef = ref(null)
 const taxRef = ref(null)
 const totalRef = ref(null)
-
-const estimateDialog = ref(false)
+const activeTab = ref('results')
+const pdfPreviewUrl = ref('')
 const estimateInfo = reactive({
     vehicleYear: '',
     vehicleMake: '',
@@ -256,10 +260,6 @@ function formatCurrency(val) {
     return Number(val).toLocaleString('en-US', { style: 'currency', currency: 'GYD' })
 }
 
-function openEstimateDialog() {
-    estimateInfo.vehicleYear = vehicleYear.value ? String(vehicleYear.value) : estimateInfo.vehicleYear
-    estimateDialog.value = true
-}
 
 function onLogoChange(e) {
     const file = e?.target?.files?.[0] || (Array.isArray(e) ? e[0] : e)
@@ -348,6 +348,8 @@ async function generateEstimatePdf() {
     const vehicleItems = [
         ['Vehicle Type:', vehicle_type.value],
         ['Vehicle Year:', estimateInfo.vehicleYear || ''],
+        ['Vehicle Make:', estimateInfo.vehicleMake || ''],
+        ['Vehicle Model:', estimateInfo.vehicleModel || ''],
         ['Engine Capacity:', cc.value ? `${cc.value} ${fuel.value === 'Electric' ? 'KW' : 'CC'}` : ''],
         ['CIF Value:', formatCurrency(results.value.cifValue)],
         ['Exchange Rate:', exchange_rate.value ? exchange_rate.value.toLocaleString('en-US', { style: 'currency', currency: 'GYD' }) : '']
@@ -418,14 +420,14 @@ async function generateEstimatePdf() {
     })
     const pdfBytes = await pdfDoc.save()
     const blob = new Blob([pdfBytes], { type: 'application/pdf' })
+    if (pdfPreviewUrl.value) URL.revokeObjectURL(pdfPreviewUrl.value)
+    pdfPreviewUrl.value = URL.createObjectURL(blob)
     const link = document.createElement('a')
-    link.href = URL.createObjectURL(blob)
+    link.href = pdfPreviewUrl.value
     link.download = 'estimate.pdf'
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-    URL.revokeObjectURL(link.href)
-    estimateDialog.value = false
 }
 
 function fitText(el) {
@@ -460,6 +462,12 @@ watch(estimateInfo, () => {
     localStorage.setItem('estimateInfo', JSON.stringify(estimateInfo))
 }, { deep: true })
 
+watch(activeTab, val => {
+    if (val === 'estimate') {
+        estimateInfo.vehicleYear = vehicleYear.value ? String(vehicleYear.value) : estimateInfo.vehicleYear
+    }
+})
+
 watch([fuel, vehicle_type, vehicleYear, plate, cc, cif, exchange_rate], () => {
     const data = {
         fuel: fuel.value,
@@ -492,6 +500,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
     window.removeEventListener('resize', updateStatSizes)
+    if (pdfPreviewUrl.value) URL.revokeObjectURL(pdfPreviewUrl.value)
 })
 
 const ageCategory = computed(() => {

--- a/app/app.vue
+++ b/app/app.vue
@@ -160,38 +160,44 @@
                           <v-card class="pa-4" rounded="xl">
                             <v-row dense>
                               <v-col cols="12" md="5">
-                                <v-form class="ios-form">
-                                  <v-sheet class="ios-section mb-6" rounded="xl" elevation="0">
-                                    <v-label class="font-weight-bold d-block mb-2">Vehicle Details</v-label>
-                                    <v-text-field v-model="estimateInfo.vehicleYear" label="Year" type="number" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.vehicleMake" label="Make" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.vehicleModel" label="Model" variant="solo" density="comfortable"></v-text-field>
-                                  </v-sheet>
-                                  <v-sheet class="ios-section mb-6" rounded="xl" elevation="0">
-                                    <v-label class="font-weight-bold d-block mb-2">Customer Details</v-label>
-                                    <v-text-field v-model="estimateInfo.customerFirstName" label="First Name" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.customerLastName" label="Last Name" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.customerEmail" label="Email" type="email" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.customerPhone" label="Phone" type="tel" variant="solo" density="comfortable"></v-text-field>
-                                  </v-sheet>
-                                  <v-sheet class="ios-section" rounded="xl" elevation="0">
-                                    <v-label class="font-weight-bold d-block mb-2">Company Details</v-label>
-                                    <v-text-field v-model="estimateInfo.companyName" label="Name" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.companyAddress" label="Address" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.companyEmail" label="Email" type="email" variant="solo" density="comfortable"></v-text-field>
-                                    <v-text-field v-model="estimateInfo.companyPhone" label="Phone" variant="solo" density="comfortable"></v-text-field>
-                                    <v-file-input label="Logo" accept="image/*" @change="onLogoChange" variant="solo" density="comfortable"></v-file-input>
-                                    <v-img v-if="estimateInfo.companyLogo" :src="estimateInfo.companyLogo" class="mt-2" max-height="100" contain></v-img>
-                                  </v-sheet>
+                                <v-form>
+                                  <v-card class="mb-6" variant="tonal" rounded="lg">
+                                    <v-card-title class="text-subtitle-1 font-weight-bold">Vehicle Details</v-card-title>
+                                    <v-card-text>
+                                      <v-text-field v-model="estimateInfo.vehicleYear" label="Year" type="number" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.vehicleMake" label="Make" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.vehicleModel" label="Model" variant="outlined"></v-text-field>
+                                    </v-card-text>
+                                  </v-card>
+                                  <v-card class="mb-6" variant="tonal" rounded="lg">
+                                    <v-card-title class="text-subtitle-1 font-weight-bold">Customer Details</v-card-title>
+                                    <v-card-text>
+                                      <v-text-field v-model="estimateInfo.customerFirstName" label="First Name" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.customerLastName" label="Last Name" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.customerEmail" label="Email" type="email" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.customerPhone" label="Phone" type="tel" variant="outlined"></v-text-field>
+                                    </v-card-text>
+                                  </v-card>
+                                  <v-card variant="tonal" rounded="lg">
+                                    <v-card-title class="text-subtitle-1 font-weight-bold">Company Details</v-card-title>
+                                    <v-card-text>
+                                      <v-text-field v-model="estimateInfo.companyName" label="Name" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.companyAddress" label="Address" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.companyEmail" label="Email" type="email" variant="outlined"></v-text-field>
+                                      <v-text-field v-model="estimateInfo.companyPhone" label="Phone" variant="outlined"></v-text-field>
+                                      <v-file-input label="Logo" accept="image/*" @change="onLogoChange" variant="outlined"></v-file-input>
+                                      <v-img v-if="estimateInfo.companyLogo" :src="estimateInfo.companyLogo" class="mt-2" max-height="100" contain></v-img>
+                                    </v-card-text>
+                                  </v-card>
                                 </v-form>
                               </v-col>
                               <v-col cols="12" md="7" class="d-flex flex-column">
-                                <v-sheet class="ios-section flex-grow-1 d-flex" rounded="xl" elevation="0" style="min-height:600px;">
+                                <v-sheet class="flex-grow-1 d-flex" rounded="xl" color="surface" style="min-height:600px;">
                                   <iframe v-if="pdfPreviewUrl" :src="pdfPreviewSrc" class="flex-grow-1 rounded-xl" style="border: none;" height="100%"></iframe>
                                   <div v-else class="d-flex align-center justify-center flex-grow-1 text-medium-emphasis">Preview will appear here</div>
                                 </v-sheet>
                                 <div class="text-center mt-4">
-                                  <v-btn color="primary" @click="downloadEstimatePdf" :disabled="!pdfPreviewUrl">Download PDF</v-btn>
+                                  <v-btn size="large" color="primary" prepend-icon="mdi-download" class="w-100" @click="downloadEstimatePdf" :disabled="!pdfPreviewUrl">Download PDF</v-btn>
                                 </div>
                               </v-col>
                             </v-row>
@@ -327,10 +333,11 @@ async function generateEstimatePdf(download = false) {
 
     if (estimateInfo.companyLogo) {
         try {
-            const imgBytes = await fetch(estimateInfo.companyLogo).then(r => r.arrayBuffer())
-            const img = estimateInfo.companyLogo.startsWith('data:image/png')
-                ? await pdfDoc.embedPng(imgBytes)
-                : await pdfDoc.embedJpg(imgBytes)
+            const base64 = estimateInfo.companyLogo.split(',')[1]
+            const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0))
+            const img = estimateInfo.companyLogo.includes('image/png')
+                ? await pdfDoc.embedPng(bytes)
+                : await pdfDoc.embedJpg(bytes)
             page.drawImage(img, { x: margin, y: y - 60, width: 60, height: 60 })
         } catch (e) { }
     }
@@ -785,16 +792,6 @@ useHead({
 .tax-breakdown .v-list-item .v-icon,
 .tax-breakdown .v-list-item span {
     color: rgba(var(--v-theme-on-surface), 0.87) !important;
-}
-
-.ios-section {
-    background-color: rgb(var(--v-theme-surface));
-    border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
-    padding: 1rem;
-}
-
-.ios-form .v-field {
-    border-radius: 0.75rem;
 }
 
 </style>

--- a/app/app.vue
+++ b/app/app.vue
@@ -158,32 +158,43 @@
                         </v-window-item>
                         <v-window-item value="estimate">
                           <v-card class="pa-4" rounded="xl">
-                            <v-form>
-                              <v-label class="font-weight-bold mb-1 d-block">Vehicle Details</v-label>
-                              <v-text-field v-model="estimateInfo.vehicleYear" label="Year" type="number"></v-text-field>
-                              <v-text-field v-model="estimateInfo.vehicleMake" label="Make"></v-text-field>
-                              <v-text-field v-model="estimateInfo.vehicleModel" label="Model"></v-text-field>
-                              <v-divider class="my-4"></v-divider>
-                              <v-label class="font-weight-bold mb-1 d-block">Customer Details</v-label>
-                              <v-text-field v-model="estimateInfo.customerFirstName" label="First Name"></v-text-field>
-                              <v-text-field v-model="estimateInfo.customerLastName" label="Last Name"></v-text-field>
-                              <v-text-field v-model="estimateInfo.customerEmail" label="Email" type="email"></v-text-field>
-                              <v-text-field v-model="estimateInfo.customerPhone" label="Phone" type="tel"></v-text-field>
-                              <v-divider class="my-4"></v-divider>
-                              <v-label class="font-weight-bold mb-1 d-block">Company Details</v-label>
-                              <v-text-field v-model="estimateInfo.companyName" label="Name"></v-text-field>
-                              <v-text-field v-model="estimateInfo.companyAddress" label="Address"></v-text-field>
-                              <v-text-field v-model="estimateInfo.companyEmail" label="Email" type="email"></v-text-field>
-                              <v-text-field v-model="estimateInfo.companyPhone" label="Phone"></v-text-field>
-                              <v-file-input label="Logo" accept="image/*" @change="onLogoChange"></v-file-input>
-                              <v-img v-if="estimateInfo.companyLogo" :src="estimateInfo.companyLogo" class="mt-2" max-height="100" contain></v-img>
-                            </v-form>
-                            <div v-if="pdfPreviewUrl" class="mt-4">
-                              <iframe :src="pdfPreviewSrc" width="100%" height="600" style="border: none;"></iframe>
-                            </div>
-                            <div class="text-center mt-4">
-                              <v-btn color="primary" @click="downloadEstimatePdf" :disabled="!pdfPreviewUrl">Download PDF</v-btn>
-                            </div>
+                            <v-row dense>
+                              <v-col cols="12" md="5">
+                                <v-form class="ios-form">
+                                  <v-sheet class="ios-section mb-6" rounded="xl" elevation="0">
+                                    <v-label class="font-weight-bold d-block mb-2">Vehicle Details</v-label>
+                                    <v-text-field v-model="estimateInfo.vehicleYear" label="Year" type="number" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.vehicleMake" label="Make" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.vehicleModel" label="Model" variant="solo" density="comfortable"></v-text-field>
+                                  </v-sheet>
+                                  <v-sheet class="ios-section mb-6" rounded="xl" elevation="0">
+                                    <v-label class="font-weight-bold d-block mb-2">Customer Details</v-label>
+                                    <v-text-field v-model="estimateInfo.customerFirstName" label="First Name" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.customerLastName" label="Last Name" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.customerEmail" label="Email" type="email" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.customerPhone" label="Phone" type="tel" variant="solo" density="comfortable"></v-text-field>
+                                  </v-sheet>
+                                  <v-sheet class="ios-section" rounded="xl" elevation="0">
+                                    <v-label class="font-weight-bold d-block mb-2">Company Details</v-label>
+                                    <v-text-field v-model="estimateInfo.companyName" label="Name" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.companyAddress" label="Address" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.companyEmail" label="Email" type="email" variant="solo" density="comfortable"></v-text-field>
+                                    <v-text-field v-model="estimateInfo.companyPhone" label="Phone" variant="solo" density="comfortable"></v-text-field>
+                                    <v-file-input label="Logo" accept="image/*" @change="onLogoChange" variant="solo" density="comfortable"></v-file-input>
+                                    <v-img v-if="estimateInfo.companyLogo" :src="estimateInfo.companyLogo" class="mt-2" max-height="100" contain></v-img>
+                                  </v-sheet>
+                                </v-form>
+                              </v-col>
+                              <v-col cols="12" md="7" class="d-flex flex-column">
+                                <v-sheet class="ios-section flex-grow-1 d-flex" rounded="xl" elevation="0" style="min-height:600px;">
+                                  <iframe v-if="pdfPreviewUrl" :src="pdfPreviewSrc" class="flex-grow-1 rounded-xl" style="border: none;" height="100%"></iframe>
+                                  <div v-else class="d-flex align-center justify-center flex-grow-1 text-medium-emphasis">Preview will appear here</div>
+                                </v-sheet>
+                                <div class="text-center mt-4">
+                                  <v-btn color="primary" @click="downloadEstimatePdf" :disabled="!pdfPreviewUrl">Download PDF</v-btn>
+                                </div>
+                              </v-col>
+                            </v-row>
                           </v-card>
                         </v-window-item>
                       </v-window>
@@ -774,6 +785,16 @@ useHead({
 .tax-breakdown .v-list-item .v-icon,
 .tax-breakdown .v-list-item span {
     color: rgba(var(--v-theme-on-surface), 0.87) !important;
+}
+
+.ios-section {
+    background-color: rgb(var(--v-theme-surface));
+    border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+    padding: 1rem;
+}
+
+.ios-form .v-field {
+    border-radius: 0.75rem;
 }
 
 </style>

--- a/app/app.vue
+++ b/app/app.vue
@@ -10,6 +10,23 @@
             </v-btn>
         </v-app-bar>
 
+        <v-dialog v-model="showDisclaimer" persistent max-width="500">
+            <v-card>
+                <v-card-title class="text-h6">Disclaimer</v-card-title>
+                <v-card-text>
+                    <p class="mb-4">
+                        This calculator is not affiliated with or endorsed by the Guyana Revenue
+                        Authority (GRA). Estimates are for guidance only.
+                    </p>
+                    <v-checkbox v-model="disclaimerChecked" label="I understand and agree"></v-checkbox>
+                </v-card-text>
+                <v-card-actions>
+                    <v-spacer></v-spacer>
+                    <v-btn color="primary" :disabled="!disclaimerChecked" @click="acceptDisclaimer">Continue</v-btn>
+                </v-card-actions>
+            </v-card>
+        </v-dialog>
+
         <v-main>
             <v-container>
                 <v-row justify="center">
@@ -240,6 +257,14 @@ function toggleTheme() {
     theme.global.name.value = isDark.value ? 'light' : 'dark';
 }
 
+// Disclaimer dialog
+const showDisclaimer = ref(false)
+const disclaimerChecked = ref(false)
+function acceptDisclaimer() {
+    localStorage.setItem('disclaimerAccepted', 'true')
+    showDisclaimer.value = false
+}
+
 // Form state
 const cif = ref(null)
 const exchange_rate = ref(215) // Set a default exchange rate
@@ -450,7 +475,15 @@ async function generateEstimatePdf(download = false) {
     if (download) {
         const link = document.createElement('a')
         link.href = pdfPreviewUrl.value
-        link.download = 'estimate.pdf'
+        const dateStr = new Date().toISOString().slice(0, 10)
+        const namePart = [estimateInfo.customerFirstName, estimateInfo.customerLastName]
+            .filter(Boolean)
+            .join('_')
+            .replace(/\s+/g, '_')
+        const fileName = namePart
+            ? `${namePart}_${dateStr}.pdf`
+            : `estimate_${Math.random().toString(36).slice(2, 8)}_${dateStr}.pdf`
+        link.download = fileName
         document.body.appendChild(link)
         link.click()
         document.body.removeChild(link)
@@ -531,6 +564,9 @@ onMounted(() => {
         cc.value = parsed.cc ?? cc.value
         cif.value = parsed.cif ?? cif.value
         exchange_rate.value = parsed.exchange_rate ?? exchange_rate.value
+    }
+    if (!localStorage.getItem('disclaimerAccepted')) {
+        showDisclaimer.value = true
     }
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "@tailwindcss/vite": "^4.1.13",
+        "jspdf": "^2.5.1",
         "nuxt": "^4.1.1",
         "tailwindcss": "^4.1.13",
         "vue": "^3.5.20",
@@ -375,6 +376,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -3336,6 +3346,13 @@
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "license": "MIT"
     },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3943,6 +3960,18 @@
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "license": "MIT"
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -3998,6 +4027,16 @@
       "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4094,6 +4133,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -4251,6 +4302,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -4522,6 +4593,18 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.45.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
+      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4616,6 +4699,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -4987,6 +5080,13 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
+    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -5303,6 +5403,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -5612,6 +5718,20 @@
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -6498,6 +6618,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
+      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.14.0",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.4.8"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.2.0",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/kleur": {
@@ -7903,6 +8041,13 @@
       "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
       "license": "MIT"
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8496,6 +8641,16 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8595,6 +8750,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -8666,6 +8828,16 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
     },
     "node_modules/rollup": {
       "version": "4.50.0",
@@ -9021,6 +9193,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -9248,6 +9430,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/svgo": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
@@ -9372,6 +9564,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -9855,6 +10057,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "dependencies": {
         "@mdi/font": "^7.4.47",
         "@tailwindcss/vite": "^4.1.13",
-        "jspdf": "^2.5.1",
         "nuxt": "^4.1.1",
+        "pdf-lib": "^1.17.1",
         "tailwindcss": "^4.1.13",
         "vue": "^3.5.20",
         "vue-router": "^4.5.1",
@@ -376,15 +376,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2501,6 +2492,24 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3346,13 +3355,6 @@
       "integrity": "sha512-LriObC2+KYZD3FzCrgWGv/qufdUy4eXrxcLgQMfYXgPbLIecKIsVBaQgUPmxSSLcjmYbDTQbMgr6qr6l/eb7Bg==",
       "license": "MIT"
     },
-    "node_modules/@types/raf": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
-      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -3960,18 +3962,6 @@
       "integrity": "sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==",
       "license": "MIT"
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -4027,16 +4017,6 @@
       "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
       "license": "Apache-2.0",
       "optional": true
-    },
-    "node_modules/base64-arraybuffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
-      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.6.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -4133,18 +4113,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -4302,26 +4270,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/canvg": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
-      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "@types/raf": "^3.4.0",
-        "core-js": "^3.8.3",
-        "raf": "^3.4.1",
-        "regenerator-runtime": "^0.13.7",
-        "rgbcolor": "^1.0.1",
-        "stackblur-canvas": "^2.0.0",
-        "svg-pathdata": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -4593,18 +4541,6 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
-    "node_modules/core-js": {
-      "version": "3.45.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.1.tgz",
-      "integrity": "sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4699,16 +4635,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
-      }
-    },
-    "node_modules/css-line-break": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
-      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -5080,13 +5006,6 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
-    "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true
-    },
     "node_modules/domutils": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
@@ -5403,12 +5322,6 @@
         }
       }
     },
-    "node_modules/fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
-      "license": "MIT"
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -5718,20 +5631,6 @@
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
-    },
-    "node_modules/html2canvas": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
-      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "css-line-break": "^2.1.0",
-        "text-segmentation": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -6618,24 +6517,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jspdf": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.1.tgz",
-      "integrity": "sha512-hXObxz7ZqoyhxET78+XR34Xu2qFGrJJ2I2bE5w4SM8eFaFEkW2xcGRVUss360fYelwRSid/jT078kbNvmoW0QA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.14.0",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
-        "fflate": "^0.4.8"
-      },
-      "optionalDependencies": {
-        "canvg": "^3.0.6",
-        "core-js": "^3.6.0",
-        "dompurify": "^2.2.0",
-        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/kleur": {
@@ -7943,6 +7824,12 @@
       "integrity": "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ==",
       "license": "MIT"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-path": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-7.1.0.tgz",
@@ -8035,18 +7922,29 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/perfect-debounce": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.0.0.tgz",
       "integrity": "sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==",
       "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8641,16 +8539,6 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
-    "node_modules/raf": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
-      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "performance-now": "^2.1.0"
-      }
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8750,13 +8638,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/regexp-tree": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
@@ -8828,16 +8709,6 @@
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
-    },
-    "node_modules/rgbcolor": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
-      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
-      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.8.15"
-      }
     },
     "node_modules/rollup": {
       "version": "4.50.0",
@@ -9193,16 +9064,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/stackblur-canvas": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
-      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.14"
-      }
-    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -9430,16 +9291,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svg-pathdata": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
-      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/svgo": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
@@ -9564,16 +9415,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
-      }
-    },
-    "node_modules/text-segmentation": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
-      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "utrie": "^1.0.2"
       }
     },
     "node_modules/tiny-invariant": {
@@ -10057,16 +9898,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
-    },
-    "node_modules/utrie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
-      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-arraybuffer": "^1.0.2"
-      }
     },
     "node_modules/vite": {
       "version": "7.1.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mdi/font": "^7.4.47",
     "@tailwindcss/vite": "^4.1.13",
+    "jspdf": "^2.5.1",
     "nuxt": "^4.1.1",
     "tailwindcss": "^4.1.13",
     "vue": "^3.5.20",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "@mdi/font": "^7.4.47",
     "@tailwindcss/vite": "^4.1.13",
-    "jspdf": "^2.5.1",
     "nuxt": "^4.1.1",
+    "pdf-lib": "^1.17.1",
     "tailwindcss": "^4.1.13",
     "vue": "^3.5.20",
     "vue-router": "^4.5.1",


### PR DESCRIPTION
## Summary
- add print estimate dialog and PDF generation using jsPDF
- store company, customer, and vehicle info in local storage
- register jspdf dependency

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc8f53b3d083239e30ff28fb21e39a